### PR TITLE
It seems that nfc_connect() has been renamed to nfc_open()

### DIFF
--- a/ext/nfc/extconf.rb
+++ b/ext/nfc/extconf.rb
@@ -15,7 +15,7 @@ unless find_header('nfc/nfc.h')
   abort "libnfc is missing.  please install libnfc: http://libnfc.org/"
 end
 
-unless find_library('nfc', 'nfc_connect')
+unless find_library('nfc', 'nfc_open')
   abort "libnfc is missing.  please install libnfc: http://libnfc.org/"
 end
 


### PR DESCRIPTION
... in the latest versions of libnfc.

Have I actually tried this change locally to prove it fixes the problem? No. Do I have near-certainty that this would fix the problem? No.

But hey... at least I'm honest. I took the first step!
