### PR TITLE
Fixed the leaks in poll_target and select_passive_target

### DIFF
--- a/ext/nfc/nfc_device.c
+++ b/ext/nfc/nfc_device.c
@@ -30,7 +30,9 @@ static VALUE select_passive_target(VALUE self, VALUE tag)
         break;
       default:
         rb_raise(rb_eRuntimeError, "untested type: %d", mod->nmt);
-    }
+    } 
+  }else {
+	xfree(ti);
   }
 
   return Qfalse;
@@ -70,6 +72,8 @@ static VALUE poll_target(VALUE self, VALUE tag, VALUE poll_nr, VALUE ms)
       default:
         rb_raise(rb_eRuntimeError, "untested type: %d", mod->nmt);
     }
+  }else {
+	xfree(ti);
   }
 
   return INT2NUM(code);


### PR DESCRIPTION
Hello! I have been using this wrapper for a few small things here and there and I found that the two mentioned functions are actually leaking. 
The fix is actually quite easy. I have tested it and it removes all the leaks I cloud find.

Cheers!
